### PR TITLE
fix: cancel setInterval when closing the window

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,13 @@ make
 ```c++
 // main.cpp
 
-setInterval(computeNextIterationLambdaFunction, interval, cancel);
+setInterval(computeNextIterationLambdaFunction, interval, cancelSetIntervalToken);
 ```
 In the `setInterval` function, we blocks the execution of the current thread until specified `sleep_time` ( current time + interval ) has been reached, then we call the function passed into the `setInterval`
 
 It works like the `setInterval` in JavaScript
+
+`cancelSetIntervalToken` is like a switch to break the cycle, without it, the `setInterval` will stop when the function exits
 
 ## Optimization
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,9 +19,9 @@ int main()
 
     window.setFramerateLimit(frameRateLimit);
 
-    auto cancel = std::make_shared<cancel_token_t>(false);
-    auto computeNextIterationLambdaFunction = computeNextIterationLambda(grid);
-    setInterval(computeNextIterationLambdaFunction, interval, cancel);
+    std::shared_ptr<std::atomic_bool> cancelSetIntervalToken = std::make_shared<std::atomic_bool>(false);
+    std::function<void()> computeNextIterationLambdaFunction = computeNextIterationLambda(grid);
+    setInterval(computeNextIterationLambdaFunction, interval, cancelSetIntervalToken);
 
     sf::Font font;
     if (!font.loadFromFile(fontPath))
@@ -47,7 +47,7 @@ int main()
 
         setupGrid(window, grid);
 
-        handleMouseAndKeyboardOperation(window, grid);
+        handleMouseAndKeyboardOperation(window, grid, cancelSetIntervalToken);
 
         window.setMouseCursorGrabbed(true);
 

--- a/src/utils/Canvas.hpp
+++ b/src/utils/Canvas.hpp
@@ -23,7 +23,7 @@ void onClickSetCellState(sf::RenderWindow &window, Grid &grid, State state);
 void handleLeftClickCell(sf::RenderWindow &window, Grid &grid);
 void handleRightClickCell(sf::RenderWindow &window, Grid &grid);
 void renderLiveCellsStatistics(sf::RenderWindow &window, Grid &grid, sf::Text &text);
-void handleMouseAndKeyboardOperation(sf::RenderWindow &window, Grid &grid);
+void handleMouseAndKeyboardOperation(sf::RenderWindow &window, Grid &grid, std::shared_ptr<std::atomic_bool> cancelSetIntervalToken);
 
 void resetTheGrid(Grid &grid)
 {
@@ -140,7 +140,7 @@ void renderLiveCellsStatistics(sf::RenderWindow &window, Grid &grid, sf::Text &t
     window.draw(text);
 }
 
-void handleMouseAndKeyboardOperation(sf::RenderWindow &window, Grid &grid)
+void handleMouseAndKeyboardOperation(sf::RenderWindow &window, Grid &grid, std::shared_ptr<std::atomic_bool> cancelSetIntervalToken)
 {
     if (sf::Mouse::isButtonPressed(sf::Mouse::Left))
     {
@@ -169,6 +169,7 @@ void handleMouseAndKeyboardOperation(sf::RenderWindow &window, Grid &grid)
 
     if (sf::Keyboard::isKeyPressed(sf::Keyboard::Q))
     {
+        *cancelSetIntervalToken = true;
         window.close();
     }
 }

--- a/src/utils/Frame.hpp
+++ b/src/utils/Frame.hpp
@@ -6,8 +6,6 @@
 #include <memory>
 #include <atomic>
 
-using cancel_token_t = std::atomic_bool;
-
 // capture reference by reference in a lambda
 // reference: https://stackoverflow.com/a/21443273
 std::function<void()> computeNextIterationLambda(Grid &grid)
@@ -22,7 +20,7 @@ std::function<void()> computeNextIterationLambda(Grid &grid)
 // JavaScript setInterval: https://developer.mozilla.org/en-US/docs/Web/API/setInterval
 // reference: https://stackoverflow.com/a/72226772
 template <typename F>
-void setInterval(F fun, std::chrono::steady_clock::duration interval, std::shared_ptr<cancel_token_t> cancel_token = nullptr)
+void setInterval(F fun, std::chrono::steady_clock::duration interval, std::shared_ptr<std::atomic_bool> cancel_token = nullptr)
 {
   std::thread([fun = std::move(fun), interval, tok = std::move(cancel_token)]()
               { 


### PR DESCRIPTION
without setting cancel token to true the `setInterval` will not stop until the `main` function exits